### PR TITLE
Legg til test fixtures

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,6 +8,7 @@ plugins {
     kotlin("plugin.serialization")
     id("org.jlleitschuh.gradle.ktlint")
     id("maven-publish")
+    id("java-test-fixtures")
 }
 
 tasks {
@@ -43,19 +44,23 @@ publishing {
 }
 
 dependencies {
-    val coroutinesVersion: String by project
     val kotestVersion: String by project
+    val kotlinCoroutinesVersion: String by project
     val kotlinxSerializationVersion: String by project
     val logbackVersion: String by project
+    val mockkVersion: String by project
     val slf4jVersion: String by project
 
     api("org.jetbrains.kotlinx:kotlinx-serialization-json:$kotlinxSerializationVersion")
     api("org.slf4j:slf4j-api:$slf4jVersion")
 
+    testFixturesImplementation("io.mockk:mockk:$mockkVersion")
+    testFixturesImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlinCoroutinesVersion")
+
     testImplementation("io.kotest:kotest-assertions-core:$kotestVersion")
     testImplementation("io.kotest:kotest-framework-datatest:$kotestVersion")
     testImplementation("io.kotest:kotest-runner-junit5:$kotestVersion")
-    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutinesVersion")
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlinCoroutinesVersion")
 
     testRuntimeOnly("ch.qos.logback:logback-classic:$logbackVersion")
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,12 +1,13 @@
 kotlin.code.style=official
 
 # Plugin versions
-kotlinVersion=1.8.21
+kotlinVersion=1.8.22
 ktlintVersion=11.3.2
 
 # Dependency versions
-coroutinesVersion=1.6.4
-kotestVersion=5.6.1
+kotestVersion=5.6.2
+kotlinCoroutinesVersion=1.7.2
 kotlinxSerializationVersion=1.5.1
-logbackVersion=1.4.7
+logbackVersion=1.4.8
+mockkVersion=1.13.5
 slf4jVersion=2.0.7

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -8,6 +8,5 @@ pluginManagement {
         kotlin("jvm") version kotlinVersion
         kotlin("plugin.serialization") version kotlinVersion
         id("org.jlleitschuh.gradle.ktlint") version ktlintVersion
-        id("maven-publish")
     }
 }

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/utils/json/serializer/GenericObjectSerializer.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/utils/json/serializer/GenericObjectSerializer.kt
@@ -1,5 +1,6 @@
 package no.nav.helsearbeidsgiver.utils.json.serializer
 
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.builtins.MapSerializer
 import kotlinx.serialization.builtins.serializer
@@ -8,6 +9,7 @@ import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.json.JsonElement
 
+@OptIn(ExperimentalSerializationApi::class)
 object GenericObjectSerializer : KSerializer<Map<String, JsonElement>> {
     private val delegateSerializer = MapSerializer(
         String.serializer(),

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/utils/json/SerializationUtilsKtTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/utils/json/SerializationUtilsKtTest.kt
@@ -5,8 +5,9 @@ import io.kotest.matchers.shouldBe
 import kotlinx.serialization.builtins.nullable
 import kotlinx.serialization.builtins.serializer
 import no.nav.helsearbeidsgiver.utils.json.serializer.set
-import java.time.LocalDate
-import java.time.LocalDateTime
+import no.nav.helsearbeidsgiver.utils.test.date.januar
+import no.nav.helsearbeidsgiver.utils.test.date.juli
+import no.nav.helsearbeidsgiver.utils.test.date.kl
 import java.time.Month
 import java.time.YearMonth
 import java.util.UUID
@@ -125,7 +126,7 @@ class SerializationUtilsKtTest : FunSpec({
         }
 
         test("serialiserer korrekt fra dato til JsonElement") {
-            val dato = LocalDate.of(1876, Month.JANUARY, 28)
+            val dato = 28.januar(1876)
 
             val json = dato.toJson().toString()
 
@@ -133,7 +134,7 @@ class SerializationUtilsKtTest : FunSpec({
         }
 
         test("serialiserer korrekt fra tidspunkt (LocalDateTime) til JsonElement") {
-            val tidspunkt = LocalDateTime.of(1777, Month.JULY, 3, 5, 47, 57, 789_012_345)
+            val tidspunkt = 3.juli(1777).kl(5, 47, 57, 789_012_345)
 
             val json = tidspunkt.toJson().toString()
 

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/utils/json/serializer/DateSerializersKtTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/utils/json/serializer/DateSerializersKtTest.kt
@@ -6,7 +6,8 @@ import io.kotest.matchers.shouldBe
 import kotlinx.serialization.SerializationException
 import no.nav.helsearbeidsgiver.utils.json.fromJson
 import no.nav.helsearbeidsgiver.utils.json.toJsonStr
-import java.time.LocalDate
+import no.nav.helsearbeidsgiver.utils.test.date.februar
+import no.nav.helsearbeidsgiver.utils.test.date.juni
 import java.time.LocalDateTime
 import java.time.Month
 import java.time.YearMonth
@@ -38,7 +39,7 @@ class DateSerializersKtTest : FunSpec({
 
     context("LocalDateSerializer") {
         test("serialiserer korrekt") {
-            val dato = LocalDate.of(1815, Month.FEBRUARY, 12)
+            val dato = 12.februar(1815)
 
             val json = dato.toJsonStr(LocalDateSerializer)
 
@@ -50,7 +51,7 @@ class DateSerializersKtTest : FunSpec({
 
             val dato = json.fromJson(LocalDateSerializer)
 
-            dato shouldBe LocalDate.of(1915, Month.JUNE, 22)
+            dato shouldBe 22.juni(1915)
         }
 
         test("gir SerializationException ved deserialiseringsfeil") {

--- a/src/testFixtures/kotlin/no/nav/helsearbeidsgiver/utils/test/date/DateUtils.kt
+++ b/src/testFixtures/kotlin/no/nav/helsearbeidsgiver/utils/test/date/DateUtils.kt
@@ -1,0 +1,123 @@
+package no.nav.helsearbeidsgiver.utils.test.date
+
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.Month
+import java.time.YearMonth
+
+// 01.01.2018 er en mandag
+private const val defaultAar = 2018
+
+val Int.januar get(): LocalDate =
+    januar(defaultAar)
+
+fun Int.januar(aar: Int): LocalDate =
+    LocalDate.of(aar, Month.JANUARY, this)
+
+fun januar(aar: Int): YearMonth =
+    1.januar(aar).toYearMonth()
+
+val Int.februar get(): LocalDate =
+    februar(defaultAar)
+
+fun Int.februar(aar: Int): LocalDate =
+    LocalDate.of(aar, Month.FEBRUARY, this)
+
+fun februar(aar: Int): YearMonth =
+    1.februar(aar).toYearMonth()
+
+val Int.mars get(): LocalDate =
+    mars(defaultAar)
+
+fun Int.mars(aar: Int): LocalDate =
+    LocalDate.of(aar, Month.MARCH, this)
+
+fun mars(aar: Int): YearMonth =
+    1.mars(aar).toYearMonth()
+
+val Int.april get(): LocalDate =
+    april(defaultAar)
+
+fun Int.april(aar: Int): LocalDate =
+    LocalDate.of(aar, Month.APRIL, this)
+
+fun april(aar: Int): YearMonth =
+    1.april(aar).toYearMonth()
+
+val Int.mai get(): LocalDate =
+    mai(defaultAar)
+
+fun Int.mai(aar: Int): LocalDate =
+    LocalDate.of(aar, Month.MAY, this)
+
+fun mai(aar: Int): YearMonth =
+    1.mai(aar).toYearMonth()
+
+val Int.juni get(): LocalDate =
+    juni(defaultAar)
+
+fun Int.juni(aar: Int): LocalDate =
+    LocalDate.of(aar, Month.JUNE, this)
+
+fun juni(aar: Int): YearMonth =
+    1.juni(aar).toYearMonth()
+
+val Int.juli get(): LocalDate =
+    juli(defaultAar)
+
+fun Int.juli(aar: Int): LocalDate =
+    LocalDate.of(aar, Month.JULY, this)
+
+fun juli(aar: Int): YearMonth =
+    1.juli(aar).toYearMonth()
+
+val Int.august get(): LocalDate =
+    august(defaultAar)
+
+fun Int.august(aar: Int): LocalDate =
+    LocalDate.of(aar, Month.AUGUST, this)
+
+fun august(aar: Int): YearMonth =
+    1.august(aar).toYearMonth()
+
+val Int.september get(): LocalDate =
+    september(defaultAar)
+
+fun Int.september(aar: Int): LocalDate =
+    LocalDate.of(aar, Month.SEPTEMBER, this)
+
+fun september(aar: Int): YearMonth =
+    1.september(aar).toYearMonth()
+
+val Int.oktober get() =
+    oktober(defaultAar)
+
+fun Int.oktober(aar: Int): LocalDate =
+    LocalDate.of(aar, Month.OCTOBER, this)
+
+fun oktober(aar: Int): YearMonth =
+    1.oktober(aar).toYearMonth()
+
+val Int.november get() =
+    november(defaultAar)
+
+fun Int.november(aar: Int): LocalDate =
+    LocalDate.of(aar, Month.NOVEMBER, this)
+
+fun november(aar: Int): YearMonth =
+    1.november(aar).toYearMonth()
+
+val Int.desember get() =
+    desember(defaultAar)
+
+fun Int.desember(aar: Int): LocalDate =
+    LocalDate.of(aar, Month.DECEMBER, this)
+
+fun desember(aar: Int): YearMonth =
+    1.desember(aar).toYearMonth()
+
+fun LocalDate.kl(time: Int, minutt: Int, sekund: Int, nanosekund: Int): LocalDateTime =
+    atTime(time, minutt, sekund, nanosekund)
+
+private fun LocalDate.toYearMonth(): YearMonth =
+    YearMonth.from(this)

--- a/src/testFixtures/kotlin/no/nav/helsearbeidsgiver/utils/test/mock/MockUtils.kt
+++ b/src/testFixtures/kotlin/no/nav/helsearbeidsgiver/utils/test/mock/MockUtils.kt
@@ -1,0 +1,46 @@
+package no.nav.helsearbeidsgiver.utils.test.mock
+
+import io.mockk.mockkConstructor
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import io.mockk.unmockkConstructor
+import io.mockk.unmockkObject
+import io.mockk.unmockkStatic
+import kotlinx.coroutines.runBlocking
+import kotlin.reflect.KClass
+
+fun <T> mockStatic(klass: KClass<*>, block: suspend () -> T): T =
+    runWithSetup(
+        block = block,
+        setup = { mockkStatic(klass) },
+        teardown = { unmockkStatic(klass) }
+    )
+
+fun <T> mockConstructor(klass: KClass<*>, block: suspend () -> T): T =
+    runWithSetup(
+        block = block,
+        setup = { mockkConstructor(klass) },
+        teardown = { unmockkConstructor(klass) }
+    )
+
+fun <T> mockObject(obj: Any, block: suspend () -> T): T =
+    runWithSetup(
+        block = block,
+        setup = { mockkObject(obj) },
+        teardown = { unmockkObject(obj) }
+    )
+
+private fun <T> runWithSetup(
+    block: suspend () -> T,
+    setup: () -> Unit,
+    teardown: () -> Unit
+): T {
+    setup()
+    return try {
+        runBlocking {
+            block()
+        }
+    } finally {
+        teardown()
+    }
+}

--- a/src/testFixtures/kotlin/no/nav/helsearbeidsgiver/utils/test/resource/ReadResource.kt
+++ b/src/testFixtures/kotlin/no/nav/helsearbeidsgiver/utils/test/resource/ReadResource.kt
@@ -1,0 +1,4 @@
+package no.nav.helsearbeidsgiver.utils.test.resource
+
+fun String.readResource(): String =
+    ClassLoader.getSystemResource(this)?.readText()!!


### PR DESCRIPTION
Test fixturer blir tilgjengeliggjort på lik linje med koden i `main`, men er tiltenkt kode som er nyttig for testing. 

Tas i bruk i et prosjekt ved å legge til avhengigheten `testImplementation(testFixtures("no.nav.helsearbeidsgiver:utils:$utilsVersion"))`.

Filene i test fixturen er hentet fra `felles-test`-modulen i https://github.com/navikt/helsearbeidsgiver-inntektsmelding, men kan være nyttig (og er duplisert) i andre repoer.