### PR TITLE
tillat nullable verdier i MDC

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 group = "no.nav.helsearbeidsgiver"
-version = "0.5.5"
+version = "0.5.6"
 
 plugins {
     kotlin("jvm")

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/utils/log/MdcUtils.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/utils/log/MdcUtils.kt
@@ -29,7 +29,7 @@ object MdcUtils {
             block = block
         )
 
-    inline fun <T> withLogFields(vararg logFields: Pair<String, String>, block: () -> T): T {
+    inline fun <T> withLogFields(vararg logFields: Pair<String, String?>, block: () -> T): T {
         val backup = logFields.map { (key, _) ->
             key to MDC.get(key)
         }

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/utils/log/MdcUtilsTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/utils/log/MdcUtilsTest.kt
@@ -173,6 +173,22 @@ class MdcUtilsTest : FunSpec({
 
             MDC.get("black").shouldBeNull()
         }
+
+        test("logger ikke null-verdier") {
+            val fnWithNonLocalReturn = fun(): String =
+                MdcUtils.withLogFields(
+                    "empty" to null,
+                    "non-empty" to "not null"
+                ) {
+                    MDC.get("empty") shouldBe null
+                    MDC.get("non-empty") shouldBe "not null"
+                }
+
+            fnWithNonLocalReturn()
+
+            MDC.get("empty").shouldBeNull()
+            MDC.get("non-empty").shouldBeNull()
+        }
     }
 })
 


### PR DESCRIPTION
 gjør det enklere for applikasjoner å logge uten å vite hvilke uuid-er som er satt / tilgjengelig