### PR TITLE
Bruk case insensitive dekoding av enums

### DIFF
--- a/src/main/kotlin/no/nav/helsearbeidsgiver/utils/json/DeserializationUtils.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/utils/json/DeserializationUtils.kt
@@ -1,5 +1,6 @@
 package no.nav.helsearbeidsgiver.utils.json
 
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.builtins.MapSerializer
 import kotlinx.serialization.json.Json
@@ -7,15 +8,17 @@ import kotlinx.serialization.json.JsonElement
 import no.nav.helsearbeidsgiver.utils.collection.mapKeysNotNull
 import no.nav.helsearbeidsgiver.utils.json.serializer.GenericObjectSerializer
 
-val jsonIgnoreUnknown = Json {
+@OptIn(ExperimentalSerializationApi::class)
+val jsonConfig = Json {
     ignoreUnknownKeys = true
+    decodeEnumsCaseInsensitive = true
 }
 
 fun String.parseJson(): JsonElement =
     Json.parseToJsonElement(this)
 
 fun <T> JsonElement.fromJson(serializer: KSerializer<T>): T =
-    jsonIgnoreUnknown.decodeFromJsonElement(serializer, this)
+    jsonConfig.decodeFromJsonElement(serializer, this)
 
 fun <T> String.fromJson(serializer: KSerializer<T>): T =
     parseJson().fromJson(serializer)

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/utils/json/DeserializationUtilsKtTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/utils/json/DeserializationUtilsKtTest.kt
@@ -31,7 +31,7 @@ class DeserializationUtilsKtTest : FunSpec({
                 age = 111
             )
 
-            val actualObject = jsonIgnoreUnknown.decodeFromJsonElement(Hobbit.serializer(), bilboJson)
+            val actualObject = jsonConfig.decodeFromJsonElement(Hobbit.serializer(), bilboJson)
 
             actualObject shouldBe expectedObject
         }


### PR DESCRIPTION
Benytter seg av den nye konfig-muligheten https://github.com/Kotlin/kotlinx.serialization/blob/v1.6.0-RC/docs/json.md#decoding-enums-in-a-case-insensitive-manner.