### PR TITLE
LocalCache: Fjern utgåtte og eldste elementer dersom cache er full

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -60,6 +60,7 @@ dependencies {
     testImplementation("io.kotest:kotest-assertions-core:$kotestVersion")
     testImplementation("io.kotest:kotest-framework-datatest:$kotestVersion")
     testImplementation("io.kotest:kotest-runner-junit5:$kotestVersion")
+    testImplementation("io.mockk:mockk:$mockkVersion")
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlinCoroutinesVersion")
 
     testRuntimeOnly("ch.qos.logback:logback-classic:$logbackVersion")


### PR DESCRIPTION
Det slo meg at ved større cachestørrelser så vil trolig flere cachede elementer være utgått når cachen blir full. Da er det mer effektivt og renske ut alt det gamle.