### PR TITLE
Cache: Støtt nullable returverdi fra default-funksjon

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,3 +12,6 @@ indent_size = 4
 trim_trailing_whitespace = true
 insert_final_newline = true
 max_line_length = 160
+
+# Ktlint
+ktlint_standard_no-unused-imports = enabled

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,8 +1,5 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
-group = "no.nav.helsearbeidsgiver"
-version = "0.10.1"
-
 plugins {
     kotlin("jvm")
     kotlin("plugin.serialization")

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,12 +2,12 @@ kotlin.code.style=official
 
 # Plugin versions
 kotlinVersion=2.3.0
-ktlintVersion=5.3.0
+kotlinterVersion=5.4.0
 
 # Dependency versions
-kotestVersion=6.0.7
+kotestVersion=6.1.1
 kotlinCoroutinesVersion=1.10.2
-kotlinxSerializationVersion=1.9.0
-logbackVersion=1.5.24
-mockkVersion=1.14.7
+kotlinxSerializationVersion=1.10.0
+logbackVersion=1.5.26
+mockkVersion=1.14.9
 slf4jVersion=2.0.17

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,8 @@
 kotlin.code.style=official
 
+group=no.nav.helsearbeidsgiver
+version=0.10.1
+
 # Plugin versions
 kotlinVersion=2.3.0
 kotlinterVersion=5.4.0

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -3,12 +3,12 @@ rootProject.name = "utils"
 pluginManagement {
     val kotestVersion: String by settings
     val kotlinVersion: String by settings
-    val ktlintVersion: String by settings
+    val kotlinterVersion: String by settings
 
     plugins {
         kotlin("jvm") version kotlinVersion
         kotlin("plugin.serialization") version kotlinVersion
-        id("org.jmailen.kotlinter") version ktlintVersion
+        id("org.jmailen.kotlinter") version kotlinterVersion
         id("io.kotest") version kotestVersion
     }
 }

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/utils/cache/LocalCache.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/utils/cache/LocalCache.kt
@@ -7,7 +7,7 @@ import java.time.LocalDateTime
 import kotlin.time.Duration
 import kotlin.time.toJavaDuration
 
-class LocalCache<T>(
+class LocalCache<T : Any>(
     private val config: Config,
 ) {
     data class Config(
@@ -28,9 +28,17 @@ class LocalCache<T>(
         default: suspend () -> T,
     ): T =
         getNotExpired(key)
-            ?: put(key, default())
+            ?: default().let { put(key, it) }
 
-    /** Parameter in `default`-function is keys which were not found in cache. */
+    /** Caches the return value from [default] only if that value is non-null. */
+    suspend fun getOrPutOrNull(
+        key: String,
+        default: suspend () -> T?,
+    ): T? =
+        getNotExpired(key)
+            ?: default()?.let { put(key, it) }
+
+    /** Parameter in [default] is keys which were not found in cache. */
     suspend fun getOrPut(
         keys: Set<String>,
         default: suspend (Set<String>) -> Map<String, T>,

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/utils/json/DeserializationUtils.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/utils/json/DeserializationUtils.kt
@@ -1,6 +1,5 @@
 package no.nav.helsearbeidsgiver.utils.json
 
-import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.builtins.MapSerializer
 import kotlinx.serialization.json.Json
@@ -8,7 +7,6 @@ import kotlinx.serialization.json.JsonElement
 import no.nav.helsearbeidsgiver.utils.collection.mapKeysNotNull
 import no.nav.helsearbeidsgiver.utils.json.serializer.GenericObjectSerializer
 
-@OptIn(ExperimentalSerializationApi::class)
 val jsonConfig =
     Json {
         ignoreUnknownKeys = true

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/utils/json/SerializationUtils.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/utils/json/SerializationUtils.kt
@@ -19,8 +19,6 @@ import java.util.UUID
 
 fun <T> T.toJson(serializer: KSerializer<T>): JsonElement = Json.encodeToJsonElement(serializer, this)
 
-fun <T> T.toJsonStr(serializer: KSerializer<T>): String = toJson(serializer).toString()
-
 fun <T> List<T>.toJson(elementSerializer: KSerializer<T>): JsonElement =
     toJson(
         elementSerializer.list(),

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/utils/json/serializer/GenericObjectSerializer.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/utils/json/serializer/GenericObjectSerializer.kt
@@ -1,6 +1,5 @@
 package no.nav.helsearbeidsgiver.utils.json.serializer
 
-import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.builtins.MapSerializer
 import kotlinx.serialization.builtins.serializer
@@ -9,7 +8,6 @@ import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.json.JsonElement
 
-@OptIn(ExperimentalSerializationApi::class)
 object GenericObjectSerializer : KSerializer<Map<String, JsonElement>> {
     private val delegateSerializer =
         MapSerializer(

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/utils/json/SerializationUtilsKtTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/utils/json/SerializationUtilsKtTest.kt
@@ -175,37 +175,4 @@ class SerializationUtilsKtTest :
                 json shouldBe "\"$fnr\""
             }
         }
-
-        context("toJsonStr") {
-            test("serialiserer korrekt fra generisk T til json-streng") {
-                val samwise =
-                    Hobbit(
-                        name = Name("Frodo", "Baggins"),
-                        age = 50,
-                    )
-
-                val expectedJson =
-                    """
-                    {
-                        "name": {
-                            "first": "Frodo",
-                            "last": "Baggins"
-                        },
-                        "age": 50
-                    }
-                    """.removeJsonWhitespace()
-
-                val actualJson = samwise.toJsonStr(Hobbit.serializer())
-
-                actualJson shouldBe expectedJson
-            }
-
-            test("serialiserer korrekt fra nullable generisk T til json-streng") {
-                val hobbitNames = listOf("Frodo", null)
-
-                val jsonList = hobbitNames.map { it.toJsonStr(String.serializer().nullable) }
-
-                jsonList shouldBe listOf("\"Frodo\"", "null")
-            }
-        }
     })

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/utils/json/serializer/AsStringSerializerTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/utils/json/serializer/AsStringSerializerTest.kt
@@ -5,7 +5,7 @@ import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import kotlinx.serialization.SerializationException
 import no.nav.helsearbeidsgiver.utils.json.fromJson
-import no.nav.helsearbeidsgiver.utils.json.toJsonStr
+import no.nav.helsearbeidsgiver.utils.json.toJson
 
 private object TestSerializer : AsStringSerializer<ChaosGod>(
     serialName = "helsearbeidsgiver.kotlinx.AsStringSerializer.test",
@@ -24,7 +24,7 @@ class AsStringSerializerTest :
                     domain = "disease and decay",
                 )
 
-            val json = nurgle.toJsonStr(TestSerializer)
+            val json = nurgle.toJson(TestSerializer).toString()
 
             json shouldBe "\"Nurgle rules disease and decay\""
         }

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/utils/json/serializer/DateSerializersKtTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/utils/json/serializer/DateSerializersKtTest.kt
@@ -5,7 +5,7 @@ import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import kotlinx.serialization.SerializationException
 import no.nav.helsearbeidsgiver.utils.json.fromJson
-import no.nav.helsearbeidsgiver.utils.json.toJsonStr
+import no.nav.helsearbeidsgiver.utils.json.toJson
 import no.nav.helsearbeidsgiver.utils.test.date.februar
 import no.nav.helsearbeidsgiver.utils.test.date.juni
 import java.time.LocalDateTime
@@ -20,7 +20,7 @@ class DateSerializersKtTest :
             test("serialiserer korrekt") {
                 val maaned = YearMonth.of(1800, Month.APRIL)
 
-                val json = maaned.toJsonStr(YearMonthSerializer)
+                val json = maaned.toJson(YearMonthSerializer).toString()
 
                 json shouldBe "\"1800-04\""
             }
@@ -44,7 +44,7 @@ class DateSerializersKtTest :
             test("serialiserer korrekt") {
                 val dato = 12.februar(1815)
 
-                val json = dato.toJsonStr(LocalDateSerializer)
+                val json = dato.toJson(LocalDateSerializer).toString()
 
                 json shouldBe "\"1815-02-12\""
             }
@@ -68,7 +68,7 @@ class DateSerializersKtTest :
             test("serialiserer korrekt") {
                 val tidspunkt = LocalDateTime.of(1830, Month.MARCH, 30, 10, 41, 42, 444_444_444)
 
-                val json = tidspunkt.toJsonStr(LocalDateTimeSerializer)
+                val json = tidspunkt.toJson(LocalDateTimeSerializer).toString()
 
                 json shouldBe "\"1830-03-30T10:41:42.444444444\""
             }
@@ -94,7 +94,7 @@ class DateSerializersKtTest :
             test("serialiserer korrekt") {
                 val tidspunkt = OffsetDateTime.of(1907, 8, 12, 12, 23, 34, 555_555_555, sevenHourOffset)
 
-                val json = tidspunkt.toJsonStr(OffsetDateTimeSerializer)
+                val json = tidspunkt.toJson(OffsetDateTimeSerializer).toString()
 
                 json shouldBe "\"1907-08-12T12:23:34.555555555+07:00\""
             }

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/utils/json/serializer/GenericObjectSerializerTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/utils/json/serializer/GenericObjectSerializerTest.kt
@@ -9,13 +9,12 @@ import kotlinx.serialization.builtins.nullable
 import kotlinx.serialization.builtins.serializer
 import no.nav.helsearbeidsgiver.utils.json.fromJson
 import no.nav.helsearbeidsgiver.utils.json.toJson
-import no.nav.helsearbeidsgiver.utils.json.toJsonStr
 import no.nav.helsearbeidsgiver.utils.test.json.removeJsonWhitespace
 
 class GenericObjectSerializerTest :
     FunSpec({
         test("serialiserer korrekt") {
-            val json = Mock.map.toJsonStr(GenericObjectSerializer)
+            val json = Mock.map.toJson(GenericObjectSerializer).toString()
 
             json shouldBe Mock.mapJson
         }

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/utils/json/serializer/SerializerUtilsKtTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/utils/json/serializer/SerializerUtilsKtTest.kt
@@ -5,7 +5,7 @@ import io.kotest.matchers.shouldBe
 import kotlinx.serialization.builtins.nullable
 import kotlinx.serialization.builtins.serializer
 import no.nav.helsearbeidsgiver.utils.json.fromJson
-import no.nav.helsearbeidsgiver.utils.json.toJsonStr
+import no.nav.helsearbeidsgiver.utils.json.toJson
 
 class SerializerUtilsKtTest :
     FunSpec({
@@ -17,7 +17,7 @@ class SerializerUtilsKtTest :
             val testSerializer = Int.serializer().nullable.list()
 
             test("serialiserer korrekt") {
-                val json = nullableInts.toJsonStr(testSerializer)
+                val json = nullableInts.toJson(testSerializer).toString()
 
                 json shouldBe nullableIntsJson
             }
@@ -36,7 +36,7 @@ class SerializerUtilsKtTest :
             val testSerializer = Double.serializer().nullable.set()
 
             test("serialiserer korrekt") {
-                val json = nullableDoubleSet.toJsonStr(testSerializer)
+                val json = nullableDoubleSet.toJson(testSerializer).toString()
 
                 json shouldBe nullableDoubleSetJson
             }

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/utils/json/serializer/UuidSerializerTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/utils/json/serializer/UuidSerializerTest.kt
@@ -5,7 +5,7 @@ import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import kotlinx.serialization.SerializationException
 import no.nav.helsearbeidsgiver.utils.json.fromJson
-import no.nav.helsearbeidsgiver.utils.json.toJsonStr
+import no.nav.helsearbeidsgiver.utils.json.toJson
 import java.util.UUID
 
 private const val MOCK_UUID = "01234567-abcd-0123-abcd-012345678901"
@@ -15,7 +15,7 @@ class UuidSerializerTest :
         test("serialiserer korrekt") {
             val uuid = UUID.fromString(MOCK_UUID)
 
-            val json = uuid.toJsonStr(UuidSerializer)
+            val json = uuid.toJson(UuidSerializer).toString()
 
             json shouldBe "\"$MOCK_UUID\""
         }

--- a/src/testFixtures/kotlin/no/nav/helsearbeidsgiver/utils/test/wrapper/Fnr.kt
+++ b/src/testFixtures/kotlin/no/nav/helsearbeidsgiver/utils/test/wrapper/Fnr.kt
@@ -25,7 +25,7 @@ fun Fnr.Companion.genererGyldig(
         val foedseldato =
             LocalDate
                 .ofYearDay(
-                    Random.nextInt(1900, 2024),
+                    Random.nextInt(1900, 2026),
                     Random.nextInt(1, 366),
                 ).format(foedselsdatoFormatter)
 


### PR DESCRIPTION
Sniker med noen andre småting her, men hovedpoenget er den nye `getOrPutOrNull` i [LocalCache]. Den kan brukes dersom man gjør et kall for å hente det som skal caches, men hvor man ikke nødvendigvis får svar eller at svaret er tomt.